### PR TITLE
Set default comment

### DIFF
--- a/go/dev/tenet/base.go
+++ b/go/dev/tenet/base.go
@@ -123,10 +123,10 @@ func (b *Base) setOpt(opt *api.Option) error {
 
 func AddComment(comment string, ctx ...CommentContext) RegisterIssueOption {
 	return func(issue *Issue) {
-
 		if issue.commentSet == nil {
 			issue.commentSet = &commentSet{}
 		}
+
 		issue.commentSet.AddComment(comment, ctx...)
 	}
 }
@@ -199,6 +199,13 @@ func (b *Base) RegisterIssue(issueName string, opts ...RegisterIssueOption) stri
 	for _, opt := range opts {
 		opt(issue)
 	}
+
+	// Add a defualt comment if tenet has not added any.
+	commSet := issue.comments()
+	if len(commSet.Comments) == 0 {
+		issue.commentSet.AddComment("Issue Found")
+	}
+
 	if b.registeredIssues == nil {
 		b.registeredIssues = map[string]*Issue{}
 	}

--- a/go/dev/tenet/base_test.go
+++ b/go/dev/tenet/base_test.go
@@ -195,7 +195,7 @@ func (s *baseSuite) TestSkipFallsBackToCustomDefaultFindsEveryIssue(c *gc.C) {
 	b.RegisterIssue("issue_with_every_line",
 		tenet.AddComment("first comment", tenet.FirstComment),
 		tenet.AddComment("third comment", tenet.ThirdComment),
-		tenet.AddComment("Custom Default Msg", tenet.DefaultComment),
+		tenet.AddComment("Custom Default Msg"),
 	)
 
 	// Add a smell which raises the above issue for every line.

--- a/go/dev/tenet/review.go
+++ b/go/dev/tenet/review.go
@@ -438,17 +438,16 @@ func (r *review) setContextualComment(issue *Issue) error {
 
 	// TODO(waigani) allow user to limit number of default comments.
 	if len(comments) == 0 {
+
 		comments = commSet.commentsForContext(DefaultComment)
 	}
 
 	// build comments with template args
 	t := template.New("comment template")
-	// default message if no comment set
-	commentTemplate := "Issue Found"
-	if len(comments) > 0 {
-		commentTemplate = comments[0].Template
-	}
-	ct, err := t.Parse(commentTemplate) // TODO(waigani) This only returns the first comment for each context.
+
+	// Note: This returns the first comment for each context.
+	// It will default to "Issue Found" if the tenet set no comments.
+	ct, err := t.Parse(comments[0].Template)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If no comment was set, a tenet would not comment on a review. While this is logical, it's also pointless. The tenet will now comment 'Issue Found' on every issue.
