### PR TITLE
New tenet and depth first node smelling

### DIFF
--- a/go/dev/tenet/base.go
+++ b/go/dev/tenet/base.go
@@ -30,10 +30,26 @@ type Base struct {
 	// tmpdir is the dir for tenets to work in.
 	tmpdir string
 
-	astVisitors  []astVisitor
-	lineVisitors []lineVisitor
+	astVisitors  astVisitors
+	lineVisitors lineVisitors
 
 	info *Info
+}
+
+type astVisitors []astVisitor
+
+func (p *astVisitors) deleteRange(a, z int) {
+	s := *p
+	s = append(s[:a], s[z+1:]...)
+	*p = s
+}
+
+type lineVisitors []lineVisitor
+
+func (p *lineVisitors) deleteRange(a, z int) {
+	s := *p
+	s = append(s[:a], s[z+1:]...)
+	*p = s
 }
 
 // base allows us to access the base struct when it's embeded in another

--- a/go/tenets/juju/tests/juju_test_assert_loop_len/.lingofile
+++ b/go/tenets/juju/tests/juju_test_assert_loop_len/.lingofile
@@ -1,0 +1,6 @@
+language = "go"
+owner = "lingoreviews"
+name = "juju_test_assert_loop_len"
+
+[docker]
+  overwrite_dockerfile=true

--- a/go/tenets/juju/tests/juju_test_assert_loop_len/README.md
+++ b/go/tenets/juju/tests/juju_test_assert_loop_len/README.md
@@ -1,0 +1,1 @@
+This license tenet checks that the first lines of the file match the provided license header.

--- a/go/tenets/juju/tests/juju_test_assert_loop_len/main.go
+++ b/go/tenets/juju/tests/juju_test_assert_loop_len/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/lingo-reviews/tenets/go/dev/server"
+	"github.com/lingo-reviews/tenets/go/tenets/juju/tests/juju_test_assert_loop_len/tenet"
+)
+
+func main() {
+	server.Serve(tenet.New())
+}

--- a/go/tenets/juju/tests/juju_test_assert_loop_len/tenet/example/.lingo
+++ b/go/tenets/juju/tests/juju_test_assert_loop_len/tenet/example/.lingo
@@ -1,0 +1,14 @@
+cascade = true
+include = "*"
+template = ""
+
+[[tenet_group]]
+  name = "default"
+  template = ""
+
+  [[tenet_group.tenet]]
+    name = "lingoreviews/juju_test_assert_loop_len"
+    driver = "binary"
+    registry = ""
+    tag = ""
+    [tenet_group.tenet.options]

--- a/go/tenets/juju/tests/juju_test_assert_loop_len/tenet/example/network.go
+++ b/go/tenets/juju/tests/juju_test_assert_loop_len/tenet/example/network.go
@@ -1,0 +1,83 @@
+package network
+
+import (
+	"strconv"
+)
+
+type server struct {
+
+	// the hostname of the server
+	host string
+
+	// ports is a map of ports on this server.
+	ports map[int]bool
+
+	on bool
+
+	// validates ports based on their membership in the pool.
+	poolValidator
+}
+
+// NewServer returns a server with the specified ports
+func NewServer(host string, ports map[int]bool) *server {
+	// If this is a new server, start the pool with it's ports.
+	if portPool == nil {
+		portPool = ports
+	} else {
+		for port, aval := range ports {
+			// we intentionally don't check if port exists for ... reasons.
+			portPool[port] = aval
+		}
+	}
+
+	s := &server{ports: ports}
+	s.start()
+	return s
+}
+
+// start the server
+func (s *server) start() {
+	if s.host == "" {
+		s.host = "localhost"
+	}
+	s.on = true
+}
+
+var portPool map[int]bool
+
+// Ports returns a map of port addresses to booleans signifiying if the ports
+// are avaliable. The returned ports are first validated so no numbers with a
+// length greater than 6 are returned.
+func (s *server) Ports() map[int]bool {
+	return s.poolValidator.validPorts(s.ports)
+}
+
+// Address returns the address of the server.
+func (s *server) Address(port string) string {
+	return s.host + ":" + port
+}
+
+type poolValidator struct {
+	inPool bool
+}
+
+// validPorts takes a map of ports and returns those that are valid. A valid
+// port has to have a length no greater than six.
+func (p poolValidator) validPorts(ports map[int]bool) map[int]bool {
+	defer func() {
+		if !p.inPool {
+			for port := range ports {
+				delete(portPool, port)
+			}
+		}
+	}()
+
+	validPorts := map[int]bool{}
+	for port, aval := range ports {
+		if len(strconv.Itoa(port)) <= 6 {
+			validPorts[port] = aval
+		}
+	}
+
+	return validPorts
+}

--- a/go/tenets/juju/tests/juju_test_assert_loop_len/tenet/example/network_test.go
+++ b/go/tenets/juju/tests/juju_test_assert_loop_len/tenet/example/network_test.go
@@ -1,0 +1,53 @@
+// Copyright 2015 Jesse Meek.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	"strconv"
+	"testing"
+
+	jt "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/lingo-reviews/tenets/go/tenets/juju/tests/juju_test_assert_loop_len/tenet/example"
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type suite struct {
+	jt.CleanupSuite
+}
+
+var _ = gc.Suite(&suite{})
+
+func (s *suite) TestServerAddress(c *gc.C) {
+	server := network.NewServer("localhost", map[int]bool{8080: true})
+	c.Assert(server.Address("8080"), gc.Equals, "localhost:8080")
+}
+
+func (s *suite) TestPortsUnder7(c *gc.C) {
+	server := network.NewServer("s1", map[int]bool{123445: false, 5678: false, 12344453: false})
+
+	// Assert Ports*() only return ports no greater than 6.
+	var portSlice []int
+	c.Assert(server.Ports(), gc.HasLen, 2)
+	for p, aval := range server.Ports() {
+		c.Assert(aval, jc.IsFalse)
+		portSlice = append(portSlice, p)
+	}
+
+	for _, p := range portSlice {
+		c.Assert(len(strconv.Itoa(p)), jc.LessThan, 7)
+	}
+}
+
+func (s *suite) TestLotsOfPorts(c *gc.C) {
+	server := network.NewServer("s2", map[int]bool{123445: false, 5678: false, 12344453: false})
+	c.Assert(server.Ports(), gc.HasLen, 2)
+	for _, aval := range server.Ports() {
+		c.Assert(aval, jc.IsFalse)
+	}
+}

--- a/go/tenets/juju/tests/juju_test_assert_loop_len/tenet/tenet.go
+++ b/go/tenets/juju/tests/juju_test_assert_loop_len/tenet/tenet.go
@@ -1,0 +1,135 @@
+// Copyright 2015 Jesse Meek.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package tenet
+
+import (
+	"go/ast"
+	"strings"
+
+	"github.com/lingo-reviews/tenets/go/dev/tenet"
+)
+
+type assertLoopLenTenet struct {
+	tenet.Base
+}
+
+func New() *assertLoopLenTenet {
+	t := &assertLoopLenTenet{}
+	t.SetInfo(tenet.Info{
+		Name:        "juju_test_assert_loop_len",
+		Usage:       "If asserting within a loop, the length of the colleciton being iterated should be asserted",
+		Description: "If asserting within a loop, the length of the colleciton being iterated should be asserted",
+		SearchTags:  []string{"test", "loop"},
+		Language:    "go",
+	})
+
+	assertLoopIssue := t.RegisterIssue("loop_len_not_asserted",
+		tenet.AddComment("The asserts within this loop may never get run. The length of the collection being looped needs to be asserted.", tenet.FirstComment),
+		tenet.AddComment("The length of this loop needs to be asserted also", tenet.DefaultComment),
+	)
+
+	// TODO(waigani) good canditate for a patch fix.
+	rangeCallExpIssue := t.RegisterIssue("range_over_call_exp",
+		tenet.AddComment(`
+Even if you assert the length of the result of this call before iterating
+over it, you cannot guarantee the result will be the same each time you call
+it. Thus, you cannot be sure that the asserts within the for loop will get
+run. Please assign the result of the call to a variable, assert the expected
+length of the variable and then loop over it.`[1:], tenet.FirstComment),
+		tenet.AddComment(`
+Here also, you can't gurantee the length of the call's result.`[1:], tenet.SecondComment),
+		tenet.AddComment(`
+Don't loop over call result.`[1:], tenet.DefaultComment),
+	)
+
+	// // First, knock out any file that isn't a test
+	t.SmellNode(func(r tenet.Review, _ *ast.File) error {
+		if !strings.HasSuffix(r.File().Filename(), "_test.go") {
+			r.FileDone()
+		}
+		return nil
+	})
+
+	// Now, the only nodes smelt are within test files.
+	// Build up a list of all collections that have an asserted len
+	var assertLen []string
+	t.SmellNode(func(r tenet.Review, callExpr *ast.CallExpr) error {
+		if fun, ok := callExpr.Fun.(*ast.SelectorExpr); ok {
+			if fun.Sel.String() != "Assert" && fun.Sel.String() != "Check" {
+				return nil
+			}
+			if args := callExpr.Args; len(args) == 3 {
+				if ident, ok := args[0].(*ast.Ident); ok {
+					// we have an assert on the collection.
+					if sel, ok := args[1].(*ast.SelectorExpr); ok {
+						if sel.Sel.String() == "HasLen" {
+							assertLen = append(assertLen, ident.String())
+							return nil
+						}
+					}
+
+				}
+
+			}
+		}
+		return nil
+	})
+
+	// Check if any range body contains an assert or check and the
+	// collection ranged over has not had an asserted length.
+	t.SmellNode(func(r tenet.Review, rngStmt *ast.RangeStmt) error {
+		if containsCheckOrAssert(rngStmt.Body.List) {
+			switch n := rngStmt.X.(type) {
+			case *ast.CallExpr:
+
+				r.RaiseNodeIssue(rangeCallExpIssue, n)
+			case *ast.Ident:
+				var checked bool
+				for _, asserted := range assertLen {
+					if n.String() == asserted {
+						checked = true
+					}
+				}
+				if !checked {
+					r.RaiseNodeIssue(assertLoopIssue, n)
+				}
+			default:
+				// TODO(waigani) log unknown range symbol
+			}
+
+		}
+		return nil
+	})
+
+	return t
+}
+
+// TODO(waigani) check for assetCustom(c) type funcs within the loop
+func containsCheckOrAssert(stmts []ast.Stmt) bool {
+	for _, stmt := range stmts {
+		switch exp := stmt.(type) {
+		case *ast.ExprStmt:
+			switch n := exp.X.(type) {
+			case (*ast.CallExpr):
+
+				switch x := n.Fun.(type) {
+				case (*ast.SelectorExpr):
+
+					for _, sel := range []string{
+						"Assert",
+						"Check",
+					} {
+						if x.Sel.String() == sel {
+							return true
+
+						}
+					}
+				}
+
+			}
+		}
+	}
+
+	return false
+}

--- a/go/tenets/juju/tests/juju_test_assert_loop_len/tenet/tenet_test.go
+++ b/go/tenets/juju/tests/juju_test_assert_loop_len/tenet/tenet_test.go
@@ -1,0 +1,64 @@
+// Copyright 2015 Jesse Meek.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// TODO(waigani) These tests demonstrate the use of several test helpers.
+// Do the same when writing tenet/seed.
+
+package tenet_test
+
+import (
+	"testing"
+
+	// TODO(matt, waigani) I've ended up calling a lot of packages "tenet".
+	// This will lead to confusion. Once the dust settles, let's think of some
+	// sane naming.
+	loop "github.com/lingo-reviews/tenets/go/tenets/juju/tests/juju_test_assert_loop_len/tenet"
+
+	tt "github.com/lingo-reviews/tenets/go/dev/tenet/testing"
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type suite struct {
+	tt.TenetSuite
+}
+
+var _ = gc.Suite(&suite{})
+
+func (s *suite) SetUpTest(c *gc.C) {
+	s.Tenet = loop.New()
+	s.TenetSuite.SetUpTest(c)
+
+}
+
+func (s *suite) TestForLoop(c *gc.C) {
+
+	files := []string{
+		"example/network_test.go",
+	}
+
+	expectedIssues := []tt.ExpectedIssue{
+		{
+			Filename: "example/network_test.go",
+			Text:     "\tfor p, aval := range server.Ports() {",
+			Comment: `
+Even if you assert the length of the result of this call before iterating
+over it, you cannot guarantee the result will be the same each time you call
+it. Thus, you cannot be sure that the asserts within the for loop will get
+run. Please assign the result of the call to a variable, assert the expected
+length of the variable and then loop over it.`[1:]}, {
+			Filename: "example/network_test.go",
+			Text:     "\tfor _, p := range portSlice {",
+			Comment:  "The asserts within this loop may never get run. The length of the collection being looped needs to be asserted.",
+		}, {
+			Filename: "example/network_test.go",
+			Text:     "\tfor _, aval := range server.Ports() {",
+			Comment:  "Here also, you can't gurantee the length of the call's result.",
+		},
+	}
+
+	s.CheckFiles(c, files, expectedIssues...)
+}

--- a/go/tenets/juju/worker/juju_worker_nostate/tenet/tenet.go
+++ b/go/tenets/juju/worker/juju_worker_nostate/tenet/tenet.go
@@ -50,8 +50,8 @@ More info here: https://github.com/juju/juju/wiki/Guidelines-for-writing-workers
 			!astutil.UsesImport(astFile, "github.com/juju/juju/worker") {
 			// This file will no longer be smelt by this tenet.
 			r.FileDone()
-		} else {
 		}
+
 		return nil
 	})
 


### PR DESCRIPTION
Add a new tenet: when asserting within a loop, the length of the
collection being iterated should be asserted.

Make SmellNode finish its ast walk before the next smell is started.

Add code to support nested smells. This is not complete. The
new code is commented out, with comments, to come back to.
